### PR TITLE
Properly classify an object when uses TextClassificationValidator

### DIFF
--- a/textclassifier/admin.py
+++ b/textclassifier/admin.py
@@ -12,6 +12,7 @@ from .models import TrainingData
 def classify_queryset(modeladmin, request, queryset, classification=SPAM):
     for obj in queryset:
         for field in obj._meta.fields:
+            value = getattr(obj, field.name)
             if (
                     # Field is a TextClassificationField
                     isinstance(field, TextClassificationField) or
@@ -20,14 +21,14 @@ def classify_queryset(modeladmin, request, queryset, classification=SPAM):
                         isinstance(validator, TextClassificationValidator)
                         for validator in field.validators
                     ])
-            ):
+            ) and value:
 
                 classifier = NaiveBayesClassifier(
                     app_label=obj._meta.app_label,
                     model=obj._meta.model_name,
-                    field_name=field.name
+                    field_name=field.name,
                 )
-                classifier.update(getattr(obj, field.name), classification)
+                classifier.update(value, classification)
 
 
 def classify_as_spam(modeladmin, request, queryset):

--- a/textclassifier/admin.py
+++ b/textclassifier/admin.py
@@ -5,13 +5,23 @@ from django.contrib import admin
 from .classifier import NaiveBayesClassifier
 from .constants import SPAM, VALID
 from .fields import TextClassificationField
+from .validators import TextClassificationValidator
 from .models import TrainingData
 
 
 def classify_queryset(modeladmin, request, queryset, classification=SPAM):
     for obj in queryset:
         for field in obj._meta.fields:
-            if isinstance(field, TextClassificationField):
+            if (
+                    # Field is a TextClassificationField
+                    isinstance(field, TextClassificationField) or
+                    # Field contains a TextClassificationValidator
+                    any([
+                        isinstance(validator, TextClassificationValidator)
+                        for validator in field.validators
+                    ])
+            ):
+
                 classifier = NaiveBayesClassifier(
                     app_label=obj._meta.app_label,
                     model=obj._meta.model_name,


### PR DESCRIPTION
The admin action was only considering the case when
TextClassificationField was used. This commit extend it to check for
TextClassificationValidator on field's validator also.